### PR TITLE
Replace brotli compression with cbor encoding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,3 @@
 **/*.rs.bk
 Cargo.lock
 .idea
-*.br

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,7 @@ travis-ci = { repository = "shekohex/mocky" }
 [dependencies]
 lazy_static = "1.3.0"
 serde = { version = "1.0.90", features = ["derive"] }
-smush = { version = "0.1.4", features = ["brotli_support"], default-features = false }
-serde_json = "1.0.39"
+serde_cbor = "0.9.0"
 rand = "0.6.5"
 
 [profile.release]
@@ -28,7 +27,9 @@ codegen-units = 1
 
 [build-dependencies]
 itertools = "0.8.0"
-smush = { version = "0.1.4", features = ["brotli_support"], default-features = false }
+serde_json = "1.0.39"
+serde_cbor = "0.9.0"
+serde-transcode = "1.1.0"
 
 [features]
 default = ["all"]

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,4 @@
-use std::{
-  env,
-  error::Error,
-  fs,
-  io::{self, prelude::*},
-  path::PathBuf,
-};
+use std::{env, fs, io::prelude::*, path::PathBuf};
 
 use itertools::Itertools;
 

--- a/build.rs
+++ b/build.rs
@@ -1,27 +1,73 @@
-use std::{env, fs, io, path::PathBuf};
+use std::{
+  env,
+  error::Error,
+  fs,
+  io::{self, prelude::*},
+  path::PathBuf,
+};
 
 use itertools::Itertools;
-use smush::{Encoding, Quality};
 
-fn main() -> io::Result<()> {
-  let features = [
-    "address", "company", "date", "lorem", "name", "phone", "system",
+fn main() {
+  let features: &[&str] = &[
+    #[cfg(feature = "address")]
+    "address",
+    #[cfg(feature = "company")]
+    "company",
+    #[cfg(feature = "date")]
+    "date",
+    #[cfg(feature = "lorem")]
+    "lorem",
+    #[cfg(feature = "name")]
+    "name",
+    #[cfg(feature = "phone")]
+    "phone",
+    #[cfg(feature = "system")]
+    "system",
   ];
-  let locales = ["en", "fr"];
-  let mut paths = Vec::with_capacity(features.len());
-  for (feat, locale) in features.iter().cartesian_product(&locales) {
-    paths.push(PathBuf::from(format!(
-      "./src/locales/{}/{}.json",
-      locale, feat
-    )));
-  }
-  for path in paths {
-    if path.exists() {
-      let data = fs::read(&path)?;
-      let bin = smush::encode(&data, Encoding::Brotli, Quality::Maximum)?;
-      let p = path.with_extension("br");
-      fs::write(p, bin)?;
+  let locales: &[&str] = &[
+    #[cfg(feature = "localization-en")]
+    "en",
+    #[cfg(feature = "localization-fr")]
+    "fr",
+  ];
+
+  // If either array is empty, but the other is not
+  if locales.is_empty() ^ features.is_empty() {
+    let mut empty_type = "language";
+    let mut non_empty_type = "data type";
+    if features.is_empty() {
+      std::mem::swap(&mut empty_type, &mut non_empty_type);
     }
+    println!("cargo:warning={} feature(s) were enabled, but no {} features were enabled. No mock data will created.",
+      non_empty_type,
+      empty_type,
+    );
   }
-  Ok(())
+
+  let output_path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
+  for locale in locales {
+    fs::create_dir_all(output_path.join(locale)).unwrap();
+  }
+  let paths = features.iter().cartesian_product(locales);
+  for (feat, locale) in paths {
+    let path = PathBuf::from(format!("./src/locales/{}/{}.json", locale, feat));
+    println!("cargo:rerun-if-changed={}", path.to_str().unwrap());
+    if !path.exists() {
+      continue;
+    }
+    let mut out_path = output_path.join(locale);
+    out_path.push(path.file_name().unwrap());
+    out_path.set_extension("cbor");
+
+    let input = fs::File::open(path).unwrap();
+
+    let mut output = fs::File::create(out_path).unwrap();
+    let mut deserializer = serde_json::Deserializer::from_reader(input);
+    let mut serializer = serde_cbor::Serializer::new(&mut output);
+
+    serde_transcode::transcode(&mut deserializer, &mut serializer).unwrap();
+    drop(serializer);
+    output.flush().unwrap();
+  }
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -76,12 +76,12 @@ impl Address {
 #[test]
 fn can_deserialize_en() {
   // Ensure accessing lazy address doesn't panic
-  let address: &Address = &*ADDRESS_EN;
+  let _: &Address = &*ADDRESS_EN;
 }
 
 #[cfg(feature = "localization-fr")]
 #[test]
 fn can_deserialize_fr() {
   // Ensure accessing lazy address doesn't panic
-  let address: &Address = &*ADDRESS_FR;
+  let _: &Address = &*ADDRESS_FR;
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -1,26 +1,26 @@
 use lazy_static::lazy_static;
 use rand::seq::SliceRandom;
 use serde::Deserialize;
-use smush::Encoding;
 
 use crate::{utils, MockyLocale};
 
 #[cfg(feature = "localization-en")]
+const ADDRESS_EN_BYTES: &'static [u8] =
+  include_bytes!(concat!(env!("OUT_DIR"), "/en/address.cbor"));
+
+#[cfg(feature = "localization-en")]
 lazy_static! {
-  static ref ADDRESS_EN_BYTES: Vec<u8> =
-    smush::decode(include_bytes!("./locales/en/address.br"), Encoding::Brotli)
-      .unwrap();
-  pub(crate) static ref ADDRESS_EN: Address =
-    serde_json::from_slice(&ADDRESS_EN_BYTES).unwrap();
+  static ref ADDRESS_EN: Address =
+    serde_cbor::from_slice(&ADDRESS_EN_BYTES).unwrap();
 }
+#[cfg(feature = "localization-fr")]
+const ADDRESS_FR_BYTES: &'static [u8] =
+  include_bytes!(concat!(env!("OUT_DIR"), "/fr/address.cbor"));
 
 #[cfg(feature = "localization-fr")]
 lazy_static! {
-  static ref ADDRESS_FR_BYTES: Vec<u8> =
-    smush::decode(include_bytes!("./locales/fr/address.br"), Encoding::Brotli)
-      .unwrap();
-  pub(crate) static ref ADDRESS_FR: Address =
-    serde_json::from_slice(&ADDRESS_FR_BYTES).unwrap();
+  static ref ADDRESS_FR: Address =
+    serde_cbor::from_slice(&ADDRESS_FR_BYTES).unwrap();
 }
 
 #[cfg(feature = "address")]
@@ -43,7 +43,7 @@ impl Address {
       #[cfg(feature = "localization-en")]
       En => &ADDRESS_EN,
       #[cfg(feature = "localization-fr")]
-      FR => &ADDRESS_FR,
+      Fr => &ADDRESS_FR,
     }
   }
 
@@ -70,4 +70,18 @@ impl Address {
       .unwrap_or_else(|| &"#####-####");
     utils::replace_symbols(postcode)
   }
+}
+
+#[cfg(feature = "localization-en")]
+#[test]
+fn can_deserialize_en() {
+  // Ensure accessing lazy address doesn't panic
+  let address: &Address = &*ADDRESS_EN;
+}
+
+#[cfg(feature = "localization-fr")]
+#[test]
+fn can_deserialize_fr() {
+  // Ensure accessing lazy address doesn't panic
+  let address: &Address = &*ADDRESS_FR;
 }

--- a/src/address.rs
+++ b/src/address.rs
@@ -5,7 +5,7 @@ use serde::Deserialize;
 use crate::{utils, MockyLocale};
 
 #[cfg(feature = "localization-en")]
-const ADDRESS_EN_BYTES: &'static [u8] =
+const ADDRESS_EN_BYTES: &[u8] =
   include_bytes!(concat!(env!("OUT_DIR"), "/en/address.cbor"));
 
 #[cfg(feature = "localization-en")]
@@ -14,7 +14,7 @@ lazy_static! {
     serde_cbor::from_slice(&ADDRESS_EN_BYTES).unwrap();
 }
 #[cfg(feature = "localization-fr")]
-const ADDRESS_FR_BYTES: &'static [u8] =
+const ADDRESS_FR_BYTES: &[u8] =
   include_bytes!(concat!(env!("OUT_DIR"), "/fr/address.cbor"));
 
 #[cfg(feature = "localization-fr")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,17 @@ pub(crate) enum MockyLocale {
   #[cfg(feature = "localization-en")]
   En,
   #[cfg(feature = "localization-fr")]
-  FR,
+  Fr,
 }
 
 #[cfg(feature = "localization-en")]
 impl Default for MockyLocale {
   fn default() -> Self { MockyLocale::En }
+}
+
+#[cfg(all(feature = "localization-fr", not(feature = "localization-en")))]
+impl Default for MockyLocale {
+  fn default() -> Self { MockyLocale::Fr }
 }
 
 #[derive(Debug, Default)]


### PR DESCRIPTION
* CBOR files end up slightly larger (~20%) than max compressed brotli from
json. In exchange, we get to reference strings directly from the file,
rather than decompressing into an intermediate in-memory copy.

* Change to write files into cargo's out directory: build scripts
should not modify any files outside of OUT_DIR

* Add super simple tests to verify that deserialization succeeds

* Renamed MockyLocale::FR to MockyLocale::Fr, to match En