### PR TITLE
Generate Alphanumeric chars without storage

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,10 +1,8 @@
-use rand::seq::SliceRandom;
-
-const ALPHA: [char; 26] = [
-  'A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O',
-  'P', 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X', 'Y', 'Z',
-];
-const DECIMALS: [char; 10] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
+use rand::{
+  distributions::{Distribution, Uniform},
+  seq::SliceRandom,
+  Rng,
+};
 
 /// parses string for symbols (numbers or letters) and replaces them
 /// appropriately (# will be replaced with number, ? with letter and * will be
@@ -12,20 +10,23 @@ const DECIMALS: [char; 10] = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'];
 pub(crate) fn replace_symbols(pattern: &str) -> String {
   let mut rng = rand::thread_rng();
   let mut result = String::with_capacity(pattern.len());
+  let mut alpha = Uniform::new_inclusive(b'A', b'Z');
+  let mut decimal = Uniform::new_inclusive(b'0', b'9');
   for c in pattern.chars() {
-    match c {
-      '#' => result.push(*DECIMALS.choose(&mut rng).unwrap()),
-      '?' => result.push(*ALPHA.choose(&mut rng).unwrap()),
+    let out_char = match c {
+      '#' => char::from(decimal.sample(&mut rng)),
+      '?' => char::from(alpha.sample(&mut rng)),
       '*' => {
-        let chance: bool = rand::random();
+        let chance: bool = rng.gen();
         if chance {
-          result.push(*DECIMALS.choose(&mut rng).unwrap())
+          char::from(decimal.sample(&mut rng))
         } else {
-          result.push(*ALPHA.choose(&mut rng).unwrap())
+          char::from(alpha.sample(&mut rng))
         }
       },
-      _ => result.push(c),
-    }
+      _ => c,
+    };
+    result.push(out_char);
   }
 
   result

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -39,20 +39,30 @@ mod tests_utils {
   fn test_replace_symbols() {
     let data = "###-###";
     let result = replace_symbols(data);
+    println!("{}", result);
     assert_eq!(result.len(), data.len());
     assert_ne!(result, data);
-    println!("{}", result);
+    assert!(result[0..3].chars().all(char::is_numeric));
+    assert!(result[4..7].chars().all(char::is_numeric));
     // ----
     let data = "???-???";
     let result = replace_symbols(data);
+    println!("{}", result);
     assert_eq!(result.len(), data.len());
     assert_ne!(result, data);
-    println!("{}", result);
+    assert!(result[0..3].chars().all(char::is_alphabetic));
+    assert!(result[4..7].chars().all(char::is_alphabetic));
     // ----
     let data = "t*#-#*";
     let result = replace_symbols(data);
+    println!("{}", result);
     assert_eq!(result.len(), data.len());
     assert_ne!(result, data);
-    println!("{}", result);
+    assert_eq!(&result[0..1], "t");
+    assert!(result[1..2].chars().all(char::is_alphanumeric));
+    assert!(result[2..3].chars().all(char::is_numeric));
+    assert_eq!(&result[3..4], "-");
+    assert!(result[4..5].chars().all(char::is_numeric));
+    assert!(result[5..6].chars().all(char::is_alphanumeric));
   }
 }


### PR DESCRIPTION
Instead of storing a static array of alpha/numeric chars, use a uniform range of bytes (unfortunately Uniform<char> isn't implemented), which we then convert to chars